### PR TITLE
Update nethermind flags

### DIFF
--- a/ansible/inventories/devnet-12/group_vars/all/images.yaml
+++ b/ansible/inventories/devnet-12/group_vars/all/images.yaml
@@ -12,7 +12,7 @@ default_ethereum_client_images:
   geth: ethpandaops/geth:master-cd58897
   erigon: ethpandaops/erigon:devel-33fc53f
   ethereumjs: ethpandaops/ethereumjs:master-c5054eb
-  nethermind: ethpandaops/nethermind:master-13b85a3
+  nethermind: nethermindeth/nethermind:master-7e6c340
   reth: ethpandaops/reth:main-b1d0dc4
 
 

--- a/ansible/inventories/devnet-12/group_vars/nethermind.yaml
+++ b/ansible/inventories/devnet-12/group_vars/nethermind.yaml
@@ -39,8 +39,7 @@ nethermind_container_command_extra_args:
   - --EthStats.Secret={{ ethstats_secret }}
   - --EthStats.Server=wss://{{ ethstats_url }}/api/
   - --log={{ log_level | upper | default('DEBUG') }}
-  - --TxPool.BlobSupportEnabled=true
-  - --TxPool.PersistentBlobStorageEnabled=true
+  - --TxPool.BlobsSupport="StorageWithReorgs"
   - --TxPool.ReportMinutes=5
 nethermind_container_pull: true
 


### PR DESCRIPTION
Nethermind recently refactored blob pool to support blob transaction reorgs, introducing an additional flag. We decided to consolidate three blob pool-related flags into one enum. This PR enables support for blob transactions + persistent blob storage + blob transactions reorgs.